### PR TITLE
Add Windows packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ playlist-player/
 
 ---
 
+## Windows Packaging
+
+Run the provided **`build_windows.bat`** script to create a standalone
+executable using PyInstaller:
+
+```cmd
+build_windows.bat
+```
+
+The resulting **`dist/PlaylistPlayer.exe`** can be distributed without
+requiring Python on the target system.
+
+---
+
 ## License
 
 MIT – free to use, modify, and distribute.

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,9 @@
+@echo off
+REM build_windows.bat - Package Playlist-Player for Windows using PyInstaller
+
+REM Ensure PyInstaller is installed
+python -m pip install pyinstaller
+
+REM Build a single-file, windowed executable
+pyinstaller --onefile --windowed --name PlaylistPlayer main.py
+

--- a/main.py
+++ b/main.py
@@ -27,6 +27,10 @@ PYSIDE_REQ = "PySide6>=6.9.0" if sys.version_info >= (3, 13) else "PySide6>=6.7,
 REQS = [PYSIDE_REQ, "python-vlc", "mutagen", "pillow"]
 
 def _ensure_env() -> None:
+    """Create a local venv and install dependencies unless running frozen."""
+    if getattr(sys, "frozen", False):
+        # When bundled by PyInstaller the libs are already packaged
+        return
     if not VENV_DIR.exists():
         venv.create(VENV_DIR, with_pip=True)
         subprocess.check_call([


### PR DESCRIPTION
## Summary
- add `build_windows.bat` for PyInstaller packaging on Windows
- document packaging process in README
- skip venv bootstrap when running from a bundled executable

## Testing
- `python -m py_compile main.py player.py scanner.py history.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_68561b3587c88323b1e4060e64eb28a9