### PR TITLE
Implement player.close

### DIFF
--- a/main.py
+++ b/main.py
@@ -459,7 +459,7 @@ class MainWindow(QWidget):
 
     # ═════════════════ 14. close ═════════════════
     def closeEvent(self,e):
-        self._player.flush_history(); self._save_state(); super().closeEvent(e)
+        self._player.close(); self._save_state(); super().closeEvent(e)
 
 # ═════════════════ 15. entry-point ═════════════════
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `_closed` flag to the player
- stop writer thread when closed
- expose `close()` and call it from `MainWindow.closeEvent`

## Testing
- `python -m py_compile player.py main.py scanner.py history.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_685748446a0c83238950e3acab9a3980