### PR TITLE
Add auto-resume feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ A minimal, Python-Qt music player that opens **`.m3u / .m3u8 / .fplite`** playli
 ## Features
 * **Folder scan** – add all playlists beneath a chosen directory  
 * **Gap-less playback** – powered by libVLC  
-* **Per-playlist history** – resumes where you left off  
-* **Embedded cover-art** – JPEG / PNG extracted automatically  
+* **Per-playlist history** – resumes where you left off
+* **Auto-resume** – optional, continue playing on startup
+* **Embedded cover-art** – JPEG / PNG extracted automatically
 * **Timeline seek** – click, drag or mouse-wheel (± 5 s, *Ctrl* ± 1 s)
 * **Light / Dark mode** – follows your OS theme
 * **Play/Pause hotkey** – responds to the global media key


### PR DESCRIPTION
## Summary
- allow auto-resume of last played playlist
- persist auto-resume in app state
- expose option via new checkbox next to play/pause button
- document new feature in README

## Testing
- `python -m py_compile main.py player.py history.py scanner.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_6857f0a726208323ad50cce53fc675b8