### PR TITLE
Fix playlist item move order

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,9 +139,10 @@ class CreatePlaylistDialog(QDialog):
         if not rows: return
         dest = [r+delta for r in rows]
         if min(dest)<0 or max(dest)>=self.list.count(): return
-        items = [self.list.takeItem(r) for r in rows]
-        for r,it in sorted(zip(dest,items)):
-            self.list.insertItem(r,it); self.list.setItemSelected(it,True)
+        items = [self.list.takeItem(r) for r in reversed(rows)]
+        for r,it in zip(dest, reversed(items)):
+            self.list.insertItem(r,it)
+            self.list.setItemSelected(it,True)
 
     def tracks(self)->List[str]:
         return [self.list.item(i).text() for i in range(self.list.count())]


### PR DESCRIPTION
## Summary
- when moving selected items in *Create Playlist*, remove from end to maintain row indices and re-insert in the original order

## Testing
- `python -m py_compile main.py scanner.py storage.py history.py player.py make_icon.py`
- `python - <<'EOF'
from collections import namedtuple

def move_sel(lst, rows, delta):
    rows = sorted(set(rows))
    dest = [r+delta for r in rows]
    if min(dest) < 0 or max(dest) >= len(lst):
        return lst
    items = [lst.pop(r) for r in reversed(rows)]
    for r, it in zip(dest, reversed(items)):
        lst.insert(r, it)
    return lst

lst = list('abcdef')
print('before', ''.join(lst))
print('after ', ''.join(move_sel(lst, [1,2], 1)))

lst = list('abcdef')
print('before', ''.join(lst))
print('after ', ''.join(move_sel(lst, [3,4], -1)))
EOF

------
https://chatgpt.com/codex/tasks/task_e_6857f86a932c8323b463e4d942e212f9