### PR TITLE
Fix VLC volume normalize flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A minimal, Python-Qt music player that opens **`.m3u / .m3u8 / .fplite`** playli
 * **Timeline seek** – click, drag or mouse-wheel (± 5 s, *Ctrl* ± 1 s)
 * **Light / Dark mode** – follows your OS theme
 * **Play/Pause hotkey** – responds to the global media key
+* **Volume normalization** – optional filter for consistent loudness
 
 ---
 

--- a/player.py
+++ b/player.py
@@ -55,7 +55,7 @@ class VLCGaplessPlayer:
     def _make_instance(self):
         opts = ["--no-video", "--quiet", *AOUT_OPTS[self._aout_mode]]
         if self._normalize:
-            opts.append("--af=normvol")
+            opts.append("--audio-filter=normvol")
         self._instance = vlc.Instance(opts)
 
     def set_output(self, mode: str):


### PR DESCRIPTION
## Summary
- use the correct `--audio-filter=normvol` option for VLC
- document volume normalization in README

## Testing
- `python -m py_compile main.py player.py scanner.py history.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_6857ffee843c8323845e83a3efc57621