### PR TITLE
Add VLC compressor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A minimal, Python-Qt music player that opens **`.m3u / .m3u8 / .fplite`** playli
 * **Light / Dark mode** – follows your OS theme
 * **Play/Pause hotkey** – responds to the global media key
 * **Volume normalization** – optional filter for consistent loudness
+* ✓ **Volume boost (compressor)** – amplifies quiet tracks
 
 ---
 

--- a/storage.py
+++ b/storage.py
@@ -52,23 +52,25 @@ def load() -> dict:
             "last": "/path" | None,
             "auto_resume": bool,
             "normalize": bool,
+            "compress": bool,
         }
     """
     try:
         data = json.loads(STATE_FILE.read_text(encoding="utf-8"))
     except Exception:
-        return {"playlists": [], "last": None, "auto_resume": False, "normalize": False}
+        return {"playlists": [], "last": None, "auto_resume": False, "normalize": False, "compress": False}
 
     if isinstance(data, list):
-        return {"playlists": data, "last": None, "auto_resume": False, "normalize": False}
+        return {"playlists": data, "last": None, "auto_resume": False, "normalize": False, "compress": False}
     if isinstance(data, dict):
         return {
             "playlists": data.get("playlists", []),
             "last": data.get("last"),
             "auto_resume": data.get("auto_resume", False),
             "normalize": data.get("normalize", False),
+            "compress": data.get("compress", False),
         }
-    return {"playlists": [], "last": None, "auto_resume": False, "normalize": False}
+    return {"playlists": [], "last": None, "auto_resume": False, "normalize": False, "compress": False}
 
 
 def save(state: dict) -> None:


### PR DESCRIPTION
## Summary
- support VLC compressor filter
- add UI checkbox for boosting quiet audio
- persist the compressor setting
- document the compressor feature

## Testing
- `python -m py_compile main.py player.py storage.py scanner.py history.py`

------
https://chatgpt.com/codex/tasks/task_e_685ef80e7924832387299b15c62ee5be