### PR TITLE
Fix Windows build script detection of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ playlist-player/
 ## Windows Packaging
 
 Run the provided **`build_windows.bat`** script to create a standalone
-executable using PyInstaller:
+executable using PyInstaller. Make sure Python 3 is available in your
+`PATH`. The script prefers the `py` launcher but falls back to `python`
+if the launcher is not installed:
 
 ```cmd
 build_windows.bat

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -13,23 +13,31 @@
 setlocal EnableExtensions
 cd /d "%~dp0"
 
+REM Determine Python launcher
+where py >nul 2>nul
+if %errorlevel%==0 (
+    set "PY=py -3"
+) else (
+    set "PY=python"
+)
+
 REM ────────────────────────────────────────────────
 REM Step 0 : generate high-DPI multi-resolution icon
 REM           (16,24,32,48,64,128,256-px layers)
 REM ────────────────────────────────────────────────
-py -3 make_icon.py
+%PY% make_icon.py
 if errorlevel 1 goto :error
 
 REM ────────────────────────────────────────────────
 REM Step 1 : install / upgrade PyInstaller
 REM ────────────────────────────────────────────────
-py -3 -m pip install --upgrade --quiet pyinstaller
+%PY% -m pip install --upgrade --quiet pyinstaller
 if errorlevel 1 goto :error
 
 REM ────────────────────────────────────────────────
 REM Step 2 : build GUI executable
 REM ────────────────────────────────────────────────
-py -3 -m PyInstaller ^
+%PY% -m PyInstaller ^
     --name "Playlist-Player" ^
     --onefile ^
     --noconsole ^


### PR DESCRIPTION
## Summary
- search for the `py` launcher and fall back to `python`
- document launcher requirement in the README

## Testing
- `python -m py_compile main.py player.py scanner.py history.py storage.py make_icon.py`

------
https://chatgpt.com/codex/tasks/task_e_685f013a71288323a8a987254a644c8f