### PR TITLE
Fix missing QToolButton import

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ from PySide6.QtWidgets import (
     QApplication, QWidget, QListWidget, QListWidgetItem, QVBoxLayout,
     QHBoxLayout, QSplitter, QPushButton, QFileDialog, QInputDialog,
     QLabel, QMessageBox, QFrame, QComboBox, QSlider, QDialog,
-    QDialogButtonBox, QCheckBox
+    QDialogButtonBox, QCheckBox, QToolButton
 )
 from PySide6.QtGui    import (
     QColor, QPalette, QPixmap, QIcon, QDragEnterEvent, QDropEvent


### PR DESCRIPTION
## Summary
- import `QToolButton` from `PySide6.QtWidgets`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f1694a11c8323a36eeb8ddeec9b8b