### PR TITLE
Improve dependency installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ requiring Python on the target system.
 
 ---
 
+## Troubleshooting
+
+If you see an error like
+
+```
+ModuleNotFoundError: No module named 'keyboard'
+```
+
+the dependencies were not installed. The first run requires an internet
+connection so `pip` can download packages. Either run `python main.py`
+once so the script can bootstrap a local **`.venv/`** (with network
+access) or install them manually using:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
 ## License
 
 MIT – free to use, modify, and distribute.

--- a/main.py
+++ b/main.py
@@ -30,10 +30,16 @@ def _ensure_env() -> None:
         return
     if not VENV_DIR.exists():
         venv.create(VENV_DIR, with_pip=True)
-        subprocess.check_call([
-            VENV_DIR / ("Scripts" if os.name=="nt" else "bin") / "pip",
-            "install", *REQS, "--quiet"
-        ])
+        try:
+            subprocess.check_call([
+                VENV_DIR / ("Scripts" if os.name=="nt" else "bin") / "pip",
+                "install", *REQS, "--quiet"
+            ])
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                "Failed to install dependencies. "
+                "Run 'pip install -r requirements.txt' manually."
+            ) from e
     sp = (VENV_DIR/"Lib/site-packages") if os.name=="nt" else \
          next((VENV_DIR/"lib").glob("python*/site-packages"))
     site.addsitedir(sp)


### PR DESCRIPTION
## Summary
- warn if automatic venv setup fails in `main.py`
- clarify in README that first run needs internet access

## Testing
- `python -m py_compile main.py history.py player.py scanner.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_685f2dbfb6c48323b2261595401a433a