### PR TITLE
Add repo-wide gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.cache
+
+# PyInstaller
+*.spec
+
+# Editor directories and files
+.idea/
+.vscode/
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini


### PR DESCRIPTION
## Summary
- add a `.gitignore` to filter typical Python build artifacts

## Testing
- `python -m py_compile history.py main.py make_icon.py player.py scanner.py storage.py`
- `pip install -r requirements.txt --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860733718f48323949916b3f1aa7b98