### PR TITLE
Fix duplicate QtWidgets imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ from PySide6.QtWidgets import (
     QApplication, QWidget, QListWidget, QListWidgetItem, QVBoxLayout,
     QHBoxLayout, QSplitter, QPushButton, QFileDialog, QInputDialog,
     QLabel, QMessageBox, QFrame, QComboBox, QSlider, QDialog,
-    QDialogButtonBox, QCheckBox, QToolButton, QLabel, QSlider
+    QDialogButtonBox, QCheckBox, QToolButton
 )
 from PySide6.QtGui    import (
     QColor, QPalette, QPixmap, QIcon, QDragEnterEvent, QDropEvent


### PR DESCRIPTION
## Summary
- remove repeated QLabel and QSlider entries in `PySide6.QtWidgets` import list

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861533b8a8c8323a42c74f5bca25e32