### PR TITLE
Ensure atomic JSON writes are flushed

### DIFF
--- a/history.py
+++ b/history.py
@@ -31,7 +31,10 @@ def load(pl: Path) -> Dict[str, Any]:
 
 def _atomic_write(path: Path, data: dict):
     tmp = path.with_suffix(".tmp")          # same directory → same volume
-    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
     tmp.replace(path)
 
 def save(pl: Path,

--- a/storage.py
+++ b/storage.py
@@ -37,7 +37,10 @@ BAK_FILE   = CFG_DIR / "appstate.bak"
 def _atomic_write(path: Path, data: Any) -> None:
     """Write *data* as UTF-8 JSON atomically and keep a .bak copy."""
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
     # create/refresh backup *before* replacement
     if path.exists():
         shutil.copy2(path, BAK_FILE)


### PR DESCRIPTION
## Summary
- guarantee temporary files are fully written before replacing
- use identical flush+fsync logic for playlist history

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855a9408f083238c115744000805ea